### PR TITLE
Update copyright to 2023

### DIFF
--- a/wiki/.vitepress/config.ts
+++ b/wiki/.vitepress/config.ts
@@ -78,7 +78,7 @@ export default defineConfig({
     },
     footer: {
       message: 'Released under the <a href="https://www.latex-project.org/lppl/">LaTeX Project Public License</a>.',
-      copyright: 'Copyright © 2020-2022 <a href="https://github.com/BITNP">BITNP</a>',
+      copyright: 'Copyright © 2020–2023 <a href="https://github.com/BITNP">BITNP</a>',
     },
   },
   markdown: {


### PR DESCRIPTION
It's 2023 now.

Besides, the hyphen is changed to an en dash.