### PR TITLE
Improve badge style

### DIFF
--- a/wiki/.vitepress/theme/custom.css
+++ b/wiki/.vitepress/theme/custom.css
@@ -24,3 +24,9 @@
   width: 100%;
   height: 100%;
 }
+
+img[src^='https://img.shields.io/badge/']
+{
+  display: inline;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Improve style for badges.

`![…](…)` (or `<img>`) 默认渲染成了`display: block`，有上下外边距，导致上方有空白，对不齐。改成`inline`就好了。

由于图片有点儿高，[默认`vertical-align: baseline`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)会往上突出一些，所以改成了`middle`。

[Relevant issue](https://github.com/markdown-it/markdown-it/issues/795).

## Before

![](https://user-images.githubusercontent.com/73375426/213615421-a8601228-8c4a-4382-bef9-5b8b04eeb6af.png)

## After

![](https://user-images.githubusercontent.com/73375426/213615847-6b75f286-d8b6-44c7-a297-bc02735f8a26.png)
