### PR TITLE
fix: ambiguous VS Code instructions

### DIFF
--- a/wiki/.vitepress/theme/custom.css
+++ b/wiki/.vitepress/theme/custom.css
@@ -25,8 +25,8 @@
   height: 100%;
 }
 
-img[src^='https://img.shields.io/badge/']
-{
+img[src^='https://img.shields.io/badge/'],
+img.icon {
   display: inline;
   vertical-align: middle;
 }

--- a/wiki/assets/codicon-go-to-file.svg
+++ b/wiki/assets/codicon-go-to-file.svg
@@ -1,0 +1,3 @@
+<!-- https://github.com/microsoft/vscode-codicons/raw/main/src/icons/go-to-file.svg -->
+<!-- Creative Commons Attribution 4.0 International Public License -->
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 5.914l2.06-2.06v-.708L5.915 1l-.707.707.043.043.25.25 1 1h-3a2.5 2.5 0 0 0 0 5H4V7h-.5a1.5 1.5 0 1 1 0-3h3L5.207 5.293 5.914 6 6 5.914zM11 2H8.328l-1-1H12l.71.29 3 3L16 5v9l-1 1H6l-1-1V6.5l1 .847V14h9V6h-4V2zm1 0v3h3l-3-3z"/></svg>

--- a/wiki/guide/configure-and-compile.md
+++ b/wiki/guide/configure-and-compile.md
@@ -55,9 +55,9 @@ xelatex --interaction=nonstopmode main
 
 ### 使用 VS Code 撰写与编译 LaTeX 模板
 
-> 首先请在 VS Code 的扩展商店中安装 LaTeX Workshop 插件。
+> 首先请在 VS Code 的扩展商店中安装 [LaTeX Workshop 插件](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop)。
 
-VS Code 的设置项目可以通过快捷键 `ctrl/cmd + ,` 打开 UI 设置界面，之后点击右上角 `Open Settings (JSON)` 按钮即可打开相应的 JSON 格式配置文件，我们在这里即可定义 LaTeX 编译工具。其中：
+VS Code 的设置项目可以通过打开 UI 设置界面（快捷键 `ctrl/cmd + ,` ），之后点击右上角 <img src="../assets/codicon-go-to-file.svg" alt="Open Settings (JSON)" title="Open Settings (JSON)" class="icon"> 按钮即可打开相应的 JSON 格式配置文件，我们在这里即可定义 LaTeX 编译工具。其中：
 
 - “编译工具”是在 `"latex-workshop.latex.tools": [ ... ]` 处进行定义，即我们在这里定义每次调用工具 `latexmk` 或 `xelatex` 时所执行的命令
 - “编译工具链”是在 `"latex-workshop.latex.recipes": [ ... ]` 处进行定义，即我们在这里定义编译整个文档的工具链。对我们的模板使用 `xelatex` 的编译方式来说，就是定义 `xelatex -> biber -> xelatex -> xelatex`「四步走」的串联过程


### PR DESCRIPTION
- LaTeX Workshop 现在有同名 fork（`manhen.latex-workshop-2`），所以加了链接。
- 快捷键放到括号里，以免误以为两步。
- 加了图标。（复制自 [codicon](https://github.com/microsoft/vscode-codicons/raw/main/src/icons/go-to-file.svg)，CC BY 4.0）

Fixes #92

![](https://github.com/BITNP/BIThesis-wiki/assets/73375426/bba1037b-001e-4e7e-bcaf-a603a9a41d24)
