### PR TITLE
fix: Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ BIThesis 是针对北京理工大学本科生毕业毕业论文、研究生学�
 
 **本项目为 [BIThesis 在线文档](https://bithesis.bitnp.net) 的代码仓库。如果你仅仅想使用 BIThesis，请访问 [BIThesis](https://github.com/BITNP/BIThesis)仓库。**
 
-> 本项目获得了 [北京理工大学教务部](https://jwc.bit.edu.cn/)、[北京理工大学计算机学院](https://cs.bit.edu.cn/) 的认可、背书与大力支持。详见：[致谢 - 官方赞助](https://bithesis.bitnp.net/guide/acknowledgements.html#%E5%AE%98%E6%96%B9%E8%B5%9E%E5%8A%A9-official-sponsors)。
+> 本项目获得了 [北京理工大学教务部](https://jwb.bit.edu.cn/)、[北京理工大学计算机学院](https://cs.bit.edu.cn/) 的认可、背书与大力支持。详见：[致谢 - 官方赞助](https://bithesis.bitnp.net/guide/acknowledgements.html#%E5%AE%98%E6%96%B9%E8%B5%9E%E5%8A%A9-official-sponsors)。
 > **研究生模板暂未与官方进行沟通。但是我们的代码从[BIT-thesis](https://github.com/BIT-thesis/LaTeX-template)迁移而来，而它曾得到了研究生院和北京理工大学学生事务中心的支持。**
 
 <h2>交流社区</h2>

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -13,9 +13,6 @@
       "pattern": "jwb.bit.edu.cn"
     },
     {
-      "pattern": "jwc.bit.edu.cn"
-    },
-    {
       "pattern": "mirrors.bit.edu.cn"
     },
     {

--- a/wiki/guide/acknowledgements.md
+++ b/wiki/guide/acknowledgements.md
@@ -100,7 +100,7 @@ const members = [
 
 **本项目获得了北京理工大学教务部、北京理工大学计算机学院的认可、背书与大力支持。**
 
-<a href="https://jwc.bit.edu.cn"><img src="https://i.loli.net/2020/03/10/5lVXDqyHCOSczjh.png" alt="Dept. of Undergraduate Academic Affairs" width="auto" height="60px"/></a> <a href="https://cs.bit.edu.cn"><img src="https://i.loli.net/2020/03/10/bXHpTfwm1jdBuCS.png" alt="School of Computer Science and Technology, BIT" width="auto" height="60px"/></a>
+<a href="https://jwb.bit.edu.cn"><img src="https://i.loli.net/2020/03/10/5lVXDqyHCOSczjh.png" alt="Dept. of Undergraduate Academic Affairs" width="auto" height="60px"/></a> <a href="https://cs.bit.edu.cn"><img src="https://i.loli.net/2020/03/10/bXHpTfwm1jdBuCS.png" alt="School of Computer Science and Technology, BIT" width="auto" height="60px"/></a>
 
 ---
 

--- a/wiki/guide/configure-and-compile.md
+++ b/wiki/guide/configure-and-compile.md
@@ -179,7 +179,7 @@ TeXstudio 的编译工具大部分已经为我们配置完毕，我们只需要�
 
 各个模板的使用指南分别位于相应模板的 Releases 文件夹内部。
 
-你可以在[模板使用手册](http://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis.pdf)中找到如何配置参数。
+你可以在[模板使用手册](https://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis.pdf)中找到如何配置参数。
 
 也可以在示例代码的注释中找到相应的说明。
 

--- a/wiki/guide/getting-started.md
+++ b/wiki/guide/getting-started.md
@@ -12,7 +12,7 @@
 ## 下载合适的 LaTeX 发行版
 
 :::warning ❗ 请注意
-BIThesis 中参考文献为了和校方规定的模板格式（[信息与文献 参考文献著录规则 - GB/T 7714-2015](http://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=7FA63E9BBA56E60471AEDAEBDE44B14C)）保持一致，使用了仅支持 TeX Live 2019 及以上版本的宏包，如果你曾经安装过 TeX Live 且目前正在使用的 TeX Live 版本不是 2019 及以上版本，那么请及时更新为最新的 TeX Live 2019 及以上版本。
+BIThesis 中参考文献为了和校方规定的模板格式（[信息与文献 参考文献著录规则 - GB/T 7714-2015](https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=7FA63E9BBA56E60471AEDAEBDE44B14C)）保持一致，使用了仅支持 TeX Live 2019 及以上版本的宏包，如果你曾经安装过 TeX Live 且目前正在使用的 TeX Live 版本不是 2019 及以上版本，那么请及时更新为最新的 TeX Live 2019 及以上版本。
 :::
 
 ### Windows 和 Linux 系统

--- a/wiki/guide/preface.md
+++ b/wiki/guide/preface.md
@@ -18,7 +18,7 @@ BIThesis 是针对北京理工大学本科以及研究生同学毕业论文制�
 **A：可以的。**
 
 - 本项目已经经由北京理工大学教务部确认，可以用于北京理工大学本科生毕业论文、毕业设计的撰写之中。更多细节，请进入文档详细了解。
-- 本项目同时也获得了 [北京理工大学教务部](https://jwc.bit.edu.cn/)、[北京理工大学计算机学院](http://cs.bit.edu.cn/) 的认可、背书与大力支持。详见：[致谢 - 官方赞助](/guide/acknowledgements.md)。
+- 本项目同时也获得了 [北京理工大学教务部](https://jwb.bit.edu.cn/)、[北京理工大学计算机学院](https://cs.bit.edu.cn/) 的认可、背书与大力支持。详见：[致谢 - 官方赞助](/guide/acknowledgements.md)。
 
 **我们正在对项目持续更新！目前，你完全可以使用现有的版本开始你的毕业设计开题报告的写作；不过与此同时，我们也在持续推进代码的升级和更新（主要是不影响使用的底层逻辑）。更多开发计划请访问我们的 [Roadmap](https://github.com/BITNP/BIThesis/projects)。想帮助这个项目持续前进？参见我们的[贡献者指南](https://github.com/BITNP/BIThesis/blob/main/contributing-zh.md)**
 


### PR DESCRIPTION
- 更新教务部网站（[jwc](https://jwc.bit.edu.cn)（教务处）→ [jwb](https://jwb.bit.edu.cn)（教务部）），不过未更新教务部的图标。
- 删除了 mlc config 中的 jwc，因为现在已无旧站。
- http → https，有些是漏写的，有些以前可能不支持。

Relates-to: https://github.com/BITNP/BIThesis/pull/371