### PR TITLE
chore: update copyright to 2024

### DIFF
--- a/wiki/.vitepress/config.mts
+++ b/wiki/.vitepress/config.mts
@@ -88,7 +88,7 @@ export default defineConfig({
     },
     footer: {
       message: 'Released under the <a href="https://www.latex-project.org/lppl/">LaTeX Project Public License</a>.',
-      copyright: 'Copyright © 2020–2023 <a href="https://github.com/BITNP">BITNP</a>',
+      copyright: 'Copyright © 2020–2024 <a href="https://github.com/BITNP">BITNP</a>',
     },
   },
   markdown: {


### PR DESCRIPTION
It's 2024 now.

Relates-to: #47