### PR TITLE
ci: 转为检查构建结果中的链接

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -5,6 +5,11 @@ max_retries = 5
 retry_wait_time = 30 # seconds
 
 exclude = [
+  # 无需检查
+  '^https://github\.com/BITNP/BIThesis-wiki/edit/main/',
+  '^file://.*/\.vitepress/dist/assets/.+\.(css|js|woff2)',
+
+  # 经常被屏蔽或访问不到
   '^https://(grd|jwb|mirrors|cs)\.bit\.edu\.cn',
   '^https://tex\.stackexchange\.com',
   '^https://www\.tablesgenerator\.com',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,14 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: pnpm lint:prettier
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vitepress-dist
+          path: wiki/.vitepress/dist/
 
   check-links:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v4
       - name: Restore the cache
@@ -35,7 +40,7 @@ jobs:
           path: .lycheecache
           key: lychee-${{ github.sha }}
           restore-keys: lychee-
-      - name: Check links
+      - name: Check links in README and other markdown files
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -43,3 +48,17 @@ jobs:
             --no-progress
             --config .github/lychee.toml
             .
+      - uses: actions/download-artifact@v4
+        with:
+          name: vitepress-dist
+          path: wiki/.vitepress/dist/
+      - name: Check links in the website
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # 必须检查构建结果，因为有些链接在 *.md 里没有，如 wiki/.vitepress/theme/link_render.ts
+          args: >-
+            --verbose
+            --no-progress
+            --config .github/lychee.toml
+            --root-dir "${{ github.workspace }}/wiki/.vitepress/dist/"
+            ./wiki/.vitepress/dist/

--- a/wiki/faq/word-font.md
+++ b/wiki/faq/word-font.md
@@ -84,7 +84,7 @@ fc-cache -fv
 
 1. 找个 Windows 系统，在`C:/Windows/Fonts/`找到`simsun.ttc`和`sim{hei,kai,fang}.ttf`，上传到 LaTeX 项目，与`main.tex`并列。
 
-2. 创建[`ctex-fontset-windows.def`](../assets/word-font-ctex-fontset-windows.def){download="ctex-fontset-windows.def"}，与`main.tex`并列，内容如下。
+2. 创建`ctex-fontset-windows.def`，与`main.tex`并列，内容如下。
 
    :::: details `ctex-fontset-windows.def`（单击展开）
 


### PR DESCRIPTION
因为有些链接在`*.md`里没有，如`wiki/.vitepress/theme/link_render.ts`负责渲染的`[[texdoc:biblatex]]`和 https://github.com/BITNP/BIThesis-wiki/issues/505#issuecomment-2799845267 预备添加的动态路由。

此外，删除了实际部署时 404 Not Found 的 http://bithesis.bitnp.net/faq/word-font-ctex-fontset-windows.def 。

改为检查构建结果后，链接大量增加，这是因为每页都有 favicon、[prev/next](https://vitepress.dev/reference/default-theme-prev-next-links) 这种固定内容。不过 rust 程序检查指向本地文件的链接非常快，增加的时间可以忽略不计。
