### PR TITLE
docs: symbols-variant 补充PDF书签

### DIFF
--- a/wiki/faq/symbols-variant.md
+++ b/wiki/faq/symbols-variant.md
@@ -15,7 +15,8 @@ tag: bithesis
 如果想要「缩略词表」，可以编辑`misc/0_symbols.tex`，直接写表格：
 
 ```latex {14-17}
-\chapter*{缩略词表}
+\chapter*{缩略词表}  % 星号表示不写入目录
+\currentpdfbookmark{缩略词表}{ch:acronym}  % 但仍加入PDF书签（详见hyperref手册）
 
 \vspace{-1ex} % 在竖直方向略微删除空白
 

--- a/wiki/faq/symbols-variant.md
+++ b/wiki/faq/symbols-variant.md
@@ -14,7 +14,7 @@ tag: bithesis
 
 如果想要「缩略词表」，可以编辑`misc/0_symbols.tex`，直接写表格：
 
-```latex {14-17}
+```latex {15-18}
 \chapter*{缩略词表}  % 星号表示不写入目录
 \currentpdfbookmark{缩略词表}{ch:acronym}  % 但仍加入PDF书签（详见hyperref手册）
 


### PR DESCRIPTION
有人问了。

> 有没有办法能在pdf的目录里加上 缩略语表？不是论文的目录是pdf自带的目录

https://symbols-variant.bithesis-wiki.pages.dev/faq/symbols-variant.html