### PR TITLE
替换部分 GitHub 链接

### DIFF
--- a/wiki/faq/where-doc.md
+++ b/wiki/faq/where-doc.md
@@ -10,7 +10,7 @@ tag:
 
 [[texdoc:bithesis]]正常在[最初下载的模板压缩包](../guide/downloading-using-templates.md)里就有，与`main.tex`并排。
 
-如果找不到了，可重新[从 CTAN 下载](http://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis.pdf)。
+如果找不到了，可重新[从 CTAN 下载](https://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis.pdf)。
 
 ## 一般宏包
 

--- a/wiki/guide/downloading-using-templates.md
+++ b/wiki/guide/downloading-using-templates.md
@@ -46,5 +46,5 @@ BIThesis 会不时更新，主要是满足学校、同学新的细节要求，�
 [mirror]: https://mirror.bit.edu.cn/github-release/BITNP/BIThesis/LatestRelease/ '北京理工大学开源镜像站 - BIThesis镜像'
 [releases]: https://github.com/BITNP/BIThesis/releases/ 'Releases · BITNP/BIThesis'
 [latest-release]: https://github.com/BITNP/BIThesis/releases/latest 'Latest Release · BITNP/BIThesis'
-[undergraduate-handbook]: https://github.com/BITNP/BIThesis/releases/latest/download/undergraduate-handbook.pdf
-[graduate-handbook]: https://github.com/BITNP/BIThesis/releases/latest/download/graduate-handbook.pdf
+[undergraduate-handbook]: https://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis-handbook-undergraduate.pdf
+[graduate-handbook]: https://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis-handbook-graduate.pdf

--- a/wiki/guide/preface.md
+++ b/wiki/guide/preface.md
@@ -71,7 +71,7 @@ BIThesis 是针对北京理工大学本科以及研究生同学毕业论文制�
 [lab-report]: https://cn.overleaf.com/docs?engine=xelatex&snip_uri=https://github.com/BITNP/BIThesis/releases/latest/download/lab-report.zip
 [graduate-thesis]: https://cn.overleaf.com/docs?engine=xelatex&snip_uri=https://github.com/BITNP/BIThesis/releases/latest/download/graduate-thesis.zip
 [open-in-overleaf]: https://img.shields.io/badge/open%20in-Overleaf-46a247?logo=overleaf&logoColor=white&labelColor=2b2b2b
-[undergraduate-handbook]: https://github.com/BITNP/BIThesis/releases/latest/download/undergraduate-handbook.pdf
-[graduate-handbook]: https://github.com/BITNP/BIThesis/releases/latest/download/graduate-handbook.pdf
+[undergraduate-handbook]: https://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis-handbook-undergraduate.pdf
+[graduate-handbook]: https://mirrors.ctan.org/macros/unicodetex/latex/bithesis/bithesis-handbook-graduate.pdf
 
 [^1]: [研究生学位论文模版；北京理工大学研究生院；2025](https://grd.bit.edu.cn/xwgz/xwgz2/wjxz_xwgz/b119746.htm)


### PR DESCRIPTION
- 快速使用指南 GitHub → CTAN
- Overleaf 链接不用改，因为 Overleaf 会直接和 GitHub 通信

CTAN刚更新，有些镜像站还没刷新，现在访问可能404。
